### PR TITLE
Fixes for ActiveJob strategy

### DIFF
--- a/lib/userlist/push/strategies.rb
+++ b/lib/userlist/push/strategies.rb
@@ -12,13 +12,13 @@ module Userlist
         return strategy unless strategy.is_a?(Symbol) || strategy.is_a?(String)
 
         require_strategy(strategy)
-        const_get(strategy.to_s.capitalize, false)
+        const_get(strategy.to_s.camelize, false)
       end
 
       def self.strategy_defined?(strategy)
         return true unless strategy.is_a?(Symbol) || strategy.is_a?(String)
 
-        const_defined?(strategy.to_s.capitalize, false)
+        const_defined?(strategy.to_s.camelize, false)
       end
 
       def self.require_strategy(strategy)

--- a/lib/userlist/push/strategies/active_job.rb
+++ b/lib/userlist/push/strategies/active_job.rb
@@ -15,10 +15,9 @@ module Userlist
 
           worker_name = options.delete(:class)
           worker_class = Object.const_get(worker_name)
-
           worker_class
             .set(options)
-            .perform_later(*args)
+            .perform_later(*normalize(args))
         end
 
       private
@@ -37,6 +36,10 @@ module Userlist
             class: 'Userlist::Push::Strategies::ActiveJob::Worker',
             queue: 'default'
           }
+        end
+
+        def normalize(args)
+          JSON.parse(JSON.generate(args))
         end
       end
     end

--- a/spec/userlist/push/strategies_spec.rb
+++ b/spec/userlist/push/strategies_spec.rb
@@ -28,6 +28,11 @@ RSpec.describe Userlist::Push::Strategies do
       expect(strategy).to be_an_instance_of(Userlist::Push::Strategies::Direct)
     end
 
+    it 'should work with an camelized string' do
+      strategy = described_class.strategy_for('active_job', config)
+      expect(strategy).to be_an_instance_of(Userlist::Push::Strategies::ActiveJob)
+    end
+
     it 'should require the given strategy' do
       expect(subject).to receive(:require).with('userlist/push/strategies/null').and_call_original
       strategy = described_class.strategy_for(:null, config)


### PR DESCRIPTION
Turns out that strategy names are just "capitalized" instead of "camelized" before being retrieved via `Object.const_get`. Therefore strategy names such as "active_job" will be transformed to "Active_job", which is not a correctly formatted class name in most cases. 

This PR adds an appropriate spec and fix for this behavior.