### PR TITLE
Enable retries on active job strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Userlist for Ruby Changelog
 
-## v0.9.1 (2024-10-21)
+## Unreleased (main)
 
 - Updates ActiveJob Worker to retry on Timeout::Error with polynomially longer wait times, up to 10 attempts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Userlist for Ruby Changelog
 
+## v0.9.1 (2024-10-21)
+
+- Updates ActiveJob Worker to retry on Timeout::Error with polynomially longer wait times, up to 10 attempts
+
 ## v0.9.0 (2024-03-19)
 
 - Allows deleteing resources by using other identifiers (like email)

--- a/lib/userlist/push/strategies/active_job/worker.rb
+++ b/lib/userlist/push/strategies/active_job/worker.rb
@@ -5,6 +5,8 @@ module Userlist
     module Strategies
       class ActiveJob
         class Worker < ::ActiveJob::Base
+          retry_on Timeout::Error, wait: :polynomially_longer, attempts: 10
+
           def perform(method, *args)
             client = Userlist::Push::Client.new
             client.public_send(method, *args)

--- a/spec/support/active_job.rb
+++ b/spec/support/active_job.rb
@@ -1,0 +1,3 @@
+require 'active_job'
+
+ActiveJob::Base.queue_adapter = :test

--- a/spec/userlist/push/strategies/active_job/worker_spec.rb
+++ b/spec/userlist/push/strategies/active_job/worker_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 require 'userlist/push/strategies/active_job/worker'
-require 'support/active_job'
 
 RSpec.describe Userlist::Push::Strategies::ActiveJob::Worker do
   subject { described_class.new(queue, config) }

--- a/spec/userlist/push/strategies/active_job/worker_spec.rb
+++ b/spec/userlist/push/strategies/active_job/worker_spec.rb
@@ -1,8 +1,7 @@
 require 'spec_helper'
 
 require 'userlist/push/strategies/active_job/worker'
-
-ActiveJob::Base.queue_adapter = :test
+require 'support/active_job'
 
 RSpec.describe Userlist::Push::Strategies::ActiveJob::Worker do
   subject { described_class.new(queue, config) }


### PR DESCRIPTION
Added retries to the Userlist::Push::Strategies::ActiveJob::Worker to handle Timeout::Error exceptions. 

The worker will now retry the job with polynomial backoff, up to 10 attempts. 

This ensures more resilience during temporary network issues or API timeouts.